### PR TITLE
(ASC-158) Improve Molecule Config Template Styling

### DIFF
--- a/moleculerize.py
+++ b/moleculerize.py
@@ -92,7 +92,7 @@ def render_molecule_template(inventory_hosts, template_file):
         str: A molecule config file populated with hosts and groups.
     """
 
-    j2_env = Environment(loader=FileSystemLoader(TEMPLATES_DIR), trim_blocks=True)
+    j2_env = Environment(loader=FileSystemLoader(TEMPLATES_DIR), trim_blocks=True, lstrip_blocks=True)
 
     try:
         return j2_env.get_template(template_file).render(hosts=inventory_hosts)

--- a/templates/molecule.yml.j2
+++ b/templates/molecule.yml.j2
@@ -13,12 +13,12 @@ lint:
 platforms:
 {% for host in hosts.keys()|sort %}
   - name: {{ host }}
-{% if hosts[host]|length > 0 %}
+  {% if hosts[host]|length > 0 %}
     groups:
-{% for group in hosts[host]|sort %}
+    {% for group in hosts[host]|sort %}
       - {{ group }}
-{% endfor %}
-{% endif %}
+    {% endfor %}
+  {% endif %}
 {% endfor %}
 provisioner:
   name: ansible


### PR DESCRIPTION
Added indentation to the Jinja2 template syntax in the "molecule.yml.j2"
template file. Added an extra option to the renderer to make sure the
resulting file has correct whitespace.