### PR TITLE
(ASC-176) Add 'pytest-rpc' Plug-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ if [[ "$(${VENV_PIP} --version)" != "pip ${PIP_TARGET}"* ]]; then
 fi
 
 # Install test suite requirements
-PIP_OPTIONS="-c ${SYS_CONSTRAINTS} -r ${SYS_REQUIREMENTS}"
+PIP_OPTIONS=-r ${SYS_REQUIREMENTS}"
 ${VENV_PIP} install ${PIP_OPTIONS} || ${VENV_PIP} install --isolated ${PIP_OPTIONS}
 ```
 

--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -39,7 +39,7 @@ if [[ "$(${VENV_PIP} --version)" != "pip ${PIP_TARGET}"* ]]; then
 fi
 
 # Install test suite requirements
-PIP_OPTIONS="-c ${SYS_CONSTRAINTS} -r ${SYS_REQUIREMENTS}"
+PIP_OPTIONS="-r ${SYS_REQUIREMENTS}"
 ${VENV_PIP} install ${PIP_OPTIONS} || ${VENV_PIP} install --isolated ${PIP_OPTIONS}
 
 # Generate moleculerized inventory from openstack-ansible dynamic inventory

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
+-c constraints.txt
 molecule
-ansible
-jinja2
-pyyaml
 mock
+-e git+https://github.com/ryan-rs/pytest-rpc.git@master#egg=pytest-rpc


### PR DESCRIPTION
Update the requirements file to automatically include the 'pytest-rpc'
plug-in. Also, cleaned-up the requirements file to remove duplicate
info. Plus added calling 'constraints.txt' automatically from the
'requirements.txt' file.

~~Do not merge until https://github.com/rcbops/pytest-rpc/pull/1 is merged.~~