### PR TITLE
(ASC-219) Manage test exit failures with trap

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -4,7 +4,7 @@
 
 ## Shell Opts ----------------------------------------------------------------
 
-set -ev
+set -x
 set -o pipefail
 export ANSIBLE_HOST_KEY_CHECKING=False
 
@@ -17,6 +17,8 @@ SYS_INVENTORY="${SYS_INVENTORY:-/opt/openstack-ansible/playbooks/inventory}"
 
 ## Main ----------------------------------------------------------------------
 
+# fail hard during setup
+set -e
 # Create virtualenv for molecule
 virtualenv --no-pip --no-setuptools --no-wheel "${SYS_VENV_NAME}"
 
@@ -57,9 +59,13 @@ for TEST in molecules/* ; do
     pushd "$TEST"
     molecule converge
     molecule verify
+    [[ $? -ne 0 ]] && RC=$?  # record non-zero exit code
     popd
 done
 
 # Gather junit.xml results
 rm -f test_results.tar  # ensure any previous results are deleted
 ls  molecules/*/molecule/*/*.xml | tar -cvf test_results.tar --files-from=-
+
+# if exit code is recorded, use it, otherwise let it exit naturally
+[[ -z ${RC+x} ]] && exit ${RC}

--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -57,6 +57,7 @@ set +e # allow test stages to return errors
 for TEST in molecules/* ; do
     ./moleculerize.py --output "$TEST/molecule/default/molecule.yml" dynamic_inventory.json
     pushd "$TEST"
+    echo "TESTING: $(git remote -v | awk '/fetch/{print $2}') at SHA $(git rev-parse HEAD)"
     molecule converge
     molecule verify
     [[ $? -ne 0 ]] && RC=$?  # record non-zero exit code


### PR DESCRIPTION
This commit alters the `execute_tests.sh` script to manage failures
with a custom `trap`. This enables all test steps of the script to get
executed, but will return the exit code of the first failing command.

The setup portion of the script is set to fail immediately, while the
test execution will iteratively complete even when one of the suites
fails. The failing exit code of any process is captured in a global `RC`
variable and is returned as the scripts exit code. This is the exit code
that is returned to the calling script used by Jenkins.

This ensures the Jenkins job will be marked as failed if a test suite
fails while enabling all tests to complete their execution.