### PR TITLE
(ASC-187) Add molecule-validate-nova-deploy submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "molecules/molecule-validate-cinder-deploy"]
 	path = molecules/molecule-validate-cinder-deploy
 	url = https://github.com/rcbops/molecule-validate-cinder-deploy
+[submodule "molecules/molecule-validate-nova-deploy"]
+	path = molecules/molecule-validate-nova-deploy
+	url = https://github.com/rcbops/molecule-validate-nova-deploy


### PR DESCRIPTION
This commit add the `molecule-validate-nova-deploy` molecule test suite
as a submodule to the system tests repo.