### PR TITLE
(ASC-242) Emit ansible inventory

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -45,11 +45,10 @@ PIP_OPTIONS="-r ${SYS_REQUIREMENTS}"
 ${VENV_PIP} install ${PIP_OPTIONS} || ${VENV_PIP} install --isolated ${PIP_OPTIONS}
 
 # Generate moleculerized inventory from openstack-ansible dynamic inventory
-if [[ -n "${MNAIO_SSH}" ]]; then
-    ${MNAIO_SSH} "${SYS_INVENTORY}/dynamic_inventory.py" > dynamic_inventory.json
-else
-    ${SYS_INVENTORY}/dynamic_inventory.py > dynamic_inventory.json
-fi
+echo "+-------------------- ANSIBLE INVENTORY --------------------+"
+${MNAIO_SSH} "${SYS_INVENTORY}/dynamic_inventory.py" > dynamic_inventory.json
+cat dynamic_inventory.json
+echo "+-------------------- ANSIBLE INVENTORY --------------------+"
 
 # Run molecule converge and verify
 # for each submodule in ${SYS_TEST_SOURCE}/molecules


### PR DESCRIPTION
This commit emits the dynamic ansible inventory so that it will be
captured. The prior conditional for `MNAIO_SSH` has been eliminated,
since the absence of this value will resolve to the same command as
constructed in the previous conditional.