### PR TITLE
ASC-318 Validate SYS_INVENTORY path

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -14,6 +14,9 @@ SYS_VENV_NAME="${SYS_VENV_NAME:-venv-molecule}"
 SYS_CONSTRAINTS="constraints.txt"
 SYS_REQUIREMENTS="requirements.txt"
 SYS_INVENTORY="${SYS_INVENTORY:-/opt/openstack-ansible/playbooks/inventory}"
+${MNAIO_SSH} test -f "${SYS_INVENTORY}/dynamic_inventory.py" || \
+    SYS_INVENTORY="/opt/openstack-ansible/inventory" && ${MNAIO_SSH} test -f "${SYS_INVENTORY}/dynamic_inventory.py" || \
+    SYS_INVENTORY="/unknown_inventory_path"
 
 ## Main ----------------------------------------------------------------------
 


### PR DESCRIPTION
The default path set for `SYS_INVENTORY` recently failed to be the
correct location for the `dynamic_inventory.py` file. This commit
verifies the existence of the file for the set `SYS_INVENTORY` value.
If it fails, it sets it to a known alternative. If the alternative
fails, it is set to an "unknown" location to assist with debugging.