### PR TITLE
(RO-4153) added python modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 -c constraints.txt
 molecule
 mock
+shade
+ipaddr
+netaddr
 -e git+https://github.com/rcbops/pytest-rpc.git@master#egg=pytest-rpc


### PR DESCRIPTION
This PR is a part of fixing issue RO-4153, as Shannon pointed out that `shade` module needs to be installed on `infra1`.

For deploying RPC0 on MNAIO, I believe the deployment is actually happening on `infra1` by:
https://github.com/rcbops/rpc-openstack/blob/d01b0dbb044e2384503cdced35575684c8be7c35/gating/pre_merge_test/run_deploy_mnaio.sh#L70

and 

https://github.com/rcbops/rpc-openstack-system-tests/blob/master/execute_tests.sh#L17

Therefore, this PR will allow system test to install Shade, Ipaddr, and Netaddr modules on `infra1` since `shade is required for this module` is the main errors in RO-4153 as Shannon pointed out. 