### PR TITLE
ASC-396 Add Environment Variable for Molecule Test Repo Name

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -59,6 +59,8 @@ set +e # allow test stages to return errors
 for TEST in molecules/* ; do
     ./moleculerize.py --output "$TEST/molecule/default/molecule.yml" dynamic_inventory.json
     pushd "$TEST"
+    # Capture the molecule test repo in the environment so "pytest-rpc" can record it.
+    export MOLECULE_TEST_REPO=$TEST
     echo "TESTING: $(git remote -v | awk '/fetch/{print $2}') at SHA $(git rev-parse HEAD)"
     molecule --debug converge
     molecule verify


### PR DESCRIPTION
In order to build a meaningful results hierarchy in qTest the molecule test
repo name needs to be capture as an environment variable. The "pytest-rpc"
plug-in will read the environment variable and record it in the JUnitXML
result file.