### PR TITLE
ASC-449 Add rpc-openstack-post-deploy molecule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = molecules/molecule-validate-glance-deploy
 	url = https://github.com/rcbops/molecule-validate-glance-deploy
 	branch = master
+[submodule "molecules/molecule-rpc-openstack-post-deploy"]
+	path = molecules/molecule-rpc-openstack-post-deploy
+	url = https://github.com/rcbops/molecule-rpc-openstack-post-deploy
+	branch = master

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ each of the release branches.
 Add new submodule in _master_ branch and set it to track _master_ branch for its
 remote origin.
 ```
-git submodule add -b master [URL to Git repo]
+git submodule add -b master [URL to Git repo] molecules/[name of Git repo]
 git submodule init
 ```
 


### PR DESCRIPTION
This commit adds the molecule-rpc-openstack-post-deploy repo as a submodule to the system tests.