### PR TITLE
ASC-458 Keep trailing newline in molecule.yml

### DIFF
--- a/moleculerize.py
+++ b/moleculerize.py
@@ -92,7 +92,11 @@ def render_molecule_template(inventory_hosts, template_file):
         str: A molecule config file populated with hosts and groups.
     """
 
-    j2_env = Environment(loader=FileSystemLoader(TEMPLATES_DIR), trim_blocks=True, lstrip_blocks=True)
+    j2_env = Environment(loader=FileSystemLoader(TEMPLATES_DIR),
+                         trim_blocks=True,
+                         lstrip_blocks=True,
+                         keep_trailing_newline=True
+                         )
 
     try:
         return j2_env.get_template(template_file).render(hosts=inventory_hosts)


### PR DESCRIPTION
This commit adds sets the jinja2 environment variable
`keep_trailing_newline` to 'True' when rendering the `molecule.yml`
file. This setting is made to allow the `molecule.yml` file to
successfully pass the `yamllint` validation that is part of the
`molecule test` and `molecule lint` processes.