### PR TITLE
ASC-537 Add molecule-openstack-ops

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,7 @@
 	path = molecules/molecule-rpc-openstack-post-deploy
 	url = https://github.com/rcbops/molecule-rpc-openstack-post-deploy
 	branch = master
+[submodule "molecules/molecule-openstack-ops"]
+	path = molecules/molecule-openstack-ops
+	url = https://github.com/rcbops/molecule-openstack-ops
+	branch = master


### PR DESCRIPTION
This commit adds the submodule for the `molecule-openstack-ops` repo.