### PR TITLE
ASC-635 Remove openstack-ops

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,3 @@
 	path = molecules/molecule-rpc-openstack-post-deploy
 	url = https://github.com/rcbops/molecule-rpc-openstack-post-deploy
 	branch = pike
-[submodule "molecules/molecule-openstack-ops"]
-	path = molecules/molecule-openstack-ops
-	url = https://github.com/rcbops/molecule-openstack-ops
-	branch = pike


### PR DESCRIPTION
The deployment of openstack-ops is not working as expected in the CI
runs of MNAIO. This commit removes the submodule entirely until this can
be sorted out.