### PR TITLE
(maint) adds pytest-ordering package to systems test

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -2,3 +2,4 @@ molecule~=2.14
 ansible==2.4.3
 pytest-rpc<1.0.0
 moleculerize~=1.0
+pytest-ordering==0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ molecule
 mock
 pytest-rpc
 moleculerize
+pytest-ordering


### PR DESCRIPTION
System tests now use pytest ordering so the package should be added to system test as well.