### PR TITLE
ASC-664 Add debug logging to molecule verify

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -64,7 +64,7 @@ for TEST in molecules/* ; do
     # Capture the molecule test repo in the environment so "pytest-rpc" can record it.
     export MOLECULE_TEST_REPO=$(echo $repo_uri | rev | cut -d'/' -f1 - | rev | cut -d. -f1)
     molecule --debug converge
-    molecule verify
+    molecule --debug verify
     [[ $? -ne 0 ]] && RC=$?  # record non-zero exit code
     popd
 done
@@ -72,6 +72,8 @@ done
 # Gather junit.xml results
 rm -f test_results.tar  # ensure any previous results are deleted
 ls  molecules/*/molecule/*/*.xml | tar -cvf test_results.tar --files-from=-
+# Gather pytest debug files
+ls  molecules/*/molecule/*/pytestdebug.log | tar -rvf test_results.tar --files-from=-
 
 # if exit code is recorded, use it, otherwise let it exit naturally
 [[ -z ${RC+x} ]] && exit ${RC}


### PR DESCRIPTION
This commit alters the execution of `molecule verify` to include the
`--debug` flag. This outputs detailed debug stack traces in the event of
a failure and writes a debug log to disk. This commit also gathers the
debug logs into the test_results.tar file with the JUnit.xml test result
content.