### PR TITLE
ASC-877 Skip tests if converge fails

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -66,6 +66,10 @@ for TEST in molecules/* ; do
     # Capture the SHA of the tests we are executing
     export MOLECULE_GIT_COMMIT=$(git rev-parse HEAD)
     molecule --debug converge
+    if [[ $? -ne 0 ]] && RC=$?; then  # do not run tests if converge fails
+        echo "CONVERGE: Failure in $(basename $TEST), verify step being skipped"
+        continue
+    fi
     molecule --debug verify
     [[ $? -ne 0 ]] && RC=$?  # record non-zero exit code
     popd


### PR DESCRIPTION
This commit updates the `execute_tests.sh` script to skip running the
`molecule verify` command against a molecule submodule if the preceding
`molecule converge` failed to complete as expected. Prior to this
commit, the tests were executed regardless of the outcome of the
converge setup which caused unexpected test failures due to the testing
environment not being set up as defined in the converge playbook.