### PR TITLE
Copy the actual inventory, rather than use the script [master]

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -13,10 +13,7 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 SYS_VENV_NAME="${SYS_VENV_NAME:-venv-molecule}"
 SYS_CONSTRAINTS="constraints.txt"
 SYS_REQUIREMENTS="requirements.txt"
-SYS_INVENTORY="${SYS_INVENTORY:-/opt/openstack-ansible/playbooks/inventory}"
-${MNAIO_SSH} test -f "${SYS_INVENTORY}/dynamic_inventory.py" || \
-    SYS_INVENTORY="/opt/openstack-ansible/inventory" && ${MNAIO_SSH} test -f "${SYS_INVENTORY}/dynamic_inventory.py" || \
-    SYS_INVENTORY="/unknown_inventory_path"
+SYS_INVENTORY="${SYS_INVENTORY:-/etc/openstack_deploy/openstack_inventory.json}"
 
 ## Main ----------------------------------------------------------------------
 
@@ -49,7 +46,13 @@ ${VENV_PIP} install ${PIP_OPTIONS} || ${VENV_PIP} install --isolated ${PIP_OPTIO
 
 # Generate moleculerized inventory from openstack-ansible dynamic inventory
 echo "+-------------------- ANSIBLE INVENTORY --------------------+"
-${MNAIO_SSH} "${SYS_INVENTORY}/dynamic_inventory.py" > dynamic_inventory.json
+if [[ -e ${SYS_INVENTORY} ]]; then
+  echo "Local inventory source found."
+  cp ${SYS_INVENTORY} dynamic_inventory.json
+else
+  echo "No local inventory source found, copying from MNAIO infra1 node instead."
+  rsync infra1:${SYS_INVENTORY} dynamic_inventory.json
+fi
 cat dynamic_inventory.json
 echo "+-------------------- ANSIBLE INVENTORY --------------------+"
 

--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -30,7 +30,7 @@ PIP_TARGET="$(awk -F= '/^pip==/ {print $3}' ${SYS_CONSTRAINTS})"
 VENV_PYTHON="${SYS_VENV_NAME}/bin/python"
 VENV_PIP="${SYS_VENV_NAME}/bin/pip"
 
-if [[ "$(${VENV_PIP} --version)" != "pip ${PIP_TARGET}"* ]]; then
+if [[ "$(${VENV_PIP} --version 2>/dev/null)" != "pip ${PIP_TARGET}"* ]]; then
     CURL_CMD="curl --silent --show-error --retry 5"
     OUTPUT_FILE="get-pip.py"
     ${CURL_CMD} https://bootstrap.pypa.io/get-pip.py > ${OUTPUT_FILE}  \


### PR DESCRIPTION
For all versions of RPC-O, the dynamic inventory script generates
a static json file in a fixed path. Rather than trying to run the
script (which has different paths depending on the OpenStack series)
we can just copy the json file.

We implement the logic to check for the presence of a local inventory
file before trying to copy it from the MNAIO infra1 source. We also
output some debug information to understand which was used when
reviewing the console output.

JIRA: RE-2030