### PR TITLE
ASC-1044 Add jmespath for json_query

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pytest-ordering
 flake8
 flake8-pytest-mark
 tox
+jmespath


### PR DESCRIPTION
This commit adds the jmespath package to the requirements in order to
enable the use of the `json_query` filter in ansible tasks.