### PR TITLE
ASC-1060 Add OpenStack SDK Python Package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ jmespath
 mock
 molecule
 moleculerize
+openstacksdk
 pytest-ordering
 pytest-rpc
 pytest-zigzag


### PR DESCRIPTION
Add the 'openstacksdk' Python package to requirements so that we can utilize
the API for validation in Molecule tests.