### PR TITLE
ASC-1146 Update "pytest-zigzag" Version Requirement

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,7 +1,7 @@
 ansible==2.4.3
-flake8-pytest-mark>=1.0.0,<2.0.0
+flake8-pytest-mark~=1.0
 molecule~=2.14
 moleculerize~=1.0
 pytest-ordering==0.5
 pytest-rpc==0.13.0
-pytest-zigzag==0.1.3
+pytest-zigzag~=0.1


### PR DESCRIPTION
Updated the "constraints.txt" file to move from a hard pin to a looser pin
that allows for non-breaking changes.

Also, I update the "flake8-pytest-mark" pin to use the same "~=" operator
to match the style of the other constraints to make things less confusing.