### PR TITLE
ASC-1191 Pin pytest to version 3.9.3

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -3,5 +3,6 @@ flake8-pytest-mark~=1.0
 molecule~=2.14
 moleculerize~=1.0
 pytest-ordering==0.5
+pytest==3.9.3
 pytest-rpc==0.13.0
 pytest-zigzag~=0.1


### PR DESCRIPTION
Version 3.10.0 of pytest is triggering python exceptions in CI when
attempting to write to the debug log. This commit add an explicit pin to
the latest known working version of pytest.