### PR TITLE
ASC-1030 Add director to shared-infra_hosts

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -112,6 +112,9 @@ director
 
 [utility_all]
 director
+
+[shared-infra_hosts]
+director
 EOD
 
 python ${INI_INVENTORY_DIR}/ini_inventory.py \


### PR DESCRIPTION
Tests in the post-deploy suite use the shared-infra_hosts group as a
target for test execution.  This commit adds this group to the synthetic
inventory when running system tests on an OSP deployment.