### PR TITLE
ASC-1196 Remove jmespath requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 -c constraints.txt
 flake8-pytest-mark
-jmespath
 mock
 molecule
 moleculerize


### PR DESCRIPTION
The jmespath package was required to perform `json_query` filters in the
ansible tasks within the system-tests submodules.  The use of the
`json_query` filter has been refactored out of the code base for those
modules so the package is not longer required.  This commit removes it
from the requirements file.

(cherry picked from commit afe4edcdcbc653eeccbd464ff238ff665ac2abad)