### PR TITLE
ASC-1179 Constrain "flake8" Version

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,5 @@
 ansible~=2.5.10
+flake8==3.5.0
 flake8-pytest-mark~=1.0
 molecule~=2.14
 moleculerize~=1.0


### PR DESCRIPTION
Constrained "flake8" to a version that is compatible with the current release
of Molecule.