### PR TITLE
ASC-1611 Fix argument arrays

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -19,6 +19,7 @@ SKIP_CONVERGE=false
 SKIP_VERIFY=false
 
 MOLECULES=()
+SCENARIOS=()
 
 ## Remove Ansible Plug-ins Prior to System Tests Execution
 
@@ -49,10 +50,10 @@ do
       export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"
       ;;
     m)
-      MOLECULES+=$OPTARG
+      MOLECULES+=("$OPTARG")
       ;;
     s)
-      SCENARIOS+=$OPTARG
+      SCENARIOS+=("$OPTARG")
       ;;
     -)
       case ${OPTARG} in
@@ -94,12 +95,12 @@ done
 ## Main ----------------------------------------------------------------------
 
 # Determine if the user specified a specific Molecule to execute or not
-if [[ -z "${MOLECULES}" ]]; then
+if [ "${#MOLECULES[@]}" -eq 0 ]; then
     MOLECULES=(molecules/*)
 fi
 
 # Determine if the user specified a specific scenario to execute or not
-if [[ -z "${SCENARIOS}" ]]; then
+if [ "${#SCENARIOS[@]}" -eq 0 ]; then
     SCENARIOS=(default)
 fi
 


### PR DESCRIPTION
This commit updates the arguments that can receive multiple values to
ensure that they append to an array rather than concatenate strings.

The evaluation of the content of the array has also been updated to use
the size of the array rather than retrieving the first value in the
array.

(cherry picked from commit 8c0a7d08bb83e6affece0de607a12e02e01aaf13)